### PR TITLE
Take Two: Social Hashtags - Fixed Twitter OAuth, added options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,51 @@
-# Social Hashtag
+# Social Hashtags
 
-**Installation**
+### Info
 
-* Upload dntly folder to the `/wp-content/plugins/` directory
+Contributors: shanaver, mandiberg, thomasrstorey, hachacha, janiceaa
+
+Tags: instagram, youtube, hashtags, videos, photos, images, API, twitter, teleportd
+
+Requires at least: 3.0.1
+
+Tested up to: 3.9
+
+License: GPLv2 or later
+
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+
+### Changes made by Team Mandiberg 
+
+(please note that the contributor & granular commit information is here: https://github.com/mandiberg/social-hashtags)
+
+* Added option to keep or remove hashtagged words in retrieved posts.
+* Added functionality to store more metadata from posts retrieved from Twitter and Instagram, including:
+  * URL to post on Twitter/Instagram
+  * URL to user on Twitter/Instagram
+  * Timestamp for post from Twitter/Instagram
+* Exposed metadata from retrieved posts to be displayed in the archive page.
+* Added option to keep or remove Emoji from retrieved posts.
+* Added option to whitelist usernames.
+* Added option to pick a wordpress user to use as the author for social-hashtag posts.
+
+
+### Future Possible Changes
+
+* Add Infinite Scroll
+* Abstract custom API token as a parameter set in Settings
+* Iron out errors when retrieving posts manually from Twitter
+
+
+###Installation
+
+* Upload all files to a `social-hashtags` folder in the `/wp-content/plugins/` directory
 * Activate the plugin through the 'Plugins' menu in WordPress
 
-**Usage**
+###Usage
 
 * Add an API source & hashtag to pull from
 * Run manually or set a cron schedule to run automatically
 
-**Notes**
+###Notes
 
 Duplicates can occur if you run it manually while it's running already.  If you get duplciates, you can delete either one, or delete both and re-run it manually - just make sure you empty the trash because it looks in the trash for existing posts as well.

--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -1,0 +1,1 @@
+oauth.php

--- a/lib/archive-social_hashtag.php
+++ b/lib/archive-social_hashtag.php
@@ -1,13 +1,41 @@
+<!--this file is The Loop for the archive page.-->
+
 <?php get_header(); ?>
 <section id="social_hashtags">
+
+
 	<?php if(have_posts()): ?>
-		<ul>
+
+		<div class="the-social-posts">
 		<?php while(have_posts()): the_post(); ?>
-			<li><a href="<?php the_permalink(); ?>"><?php the_content(); ?></a></li>
+			<div class="a-social-post">
+				<a href="<?php the_permalink(); ?>">
+					<?php
+						$content = get_post_field('post_content', get_the_ID()); 
+						if (strpos($content,'<img') !== false) {
+    						echo $content;
+						}
+						//the_content(); 
+					?>
+				</a>
+					<?php
+						echo "<a href='" . get_post_meta(get_the_ID(), 'social_hashtag_user_link', true) . "'>";
+								echo "@" . get_post_meta(get_the_ID(), 'social_hashtag_userhandle', true);
+						echo "</a>";
+						echo "<a href='" . get_post_meta(get_the_ID(), 'social_hashtag_post_link', true) . "'>";
+								echo " on " . get_post_meta(get_the_ID(), 'social_hashtag_platform', true);
+					?>
+				</a>
+				<p><?php the_title(); ?></p>
+			</div>
 		<?php endwhile; ?>
-		</ul>
+		</div>
+		
+
 	<?php else: ?>
 		<h4>No Content was found</h4>
 	<?php endif; ?>
+		<p class="clear"> &nbsp; </p>
+		 <?php posts_nav_link( $sep, $prelabel, $nextlabel ); ?> 
 </section>
 <?php get_footer(); ?>

--- a/lib/oauthToken.php
+++ b/lib/oauthToken.php
@@ -1,0 +1,6 @@
+<?php
+//where your app credentials should go ~
+$app_key = '';
+$app_token = '';
+
+?>

--- a/lib/platforms.class.php
+++ b/lib/platforms.class.php
@@ -17,6 +17,7 @@ class PLATFORM_BASE {
   var $pic_platform;
   var $pic_strs;
   var $pic_tags;
+  var $pic_link;
   
   var $pic_full_title;
   var $pic_clean_title;
@@ -33,18 +34,48 @@ class PLATFORM_BASE {
     unset($this->pic_tags);
     unset($this->pic_loc);
   }
-  
-  function strip_urls($url) {
-    $U = explode(' ',$url);
 
-    $W =array();
-    foreach ($U as $k => $u) {
-      if (stristr($u,'http') || (count(explode('.',$u)) > 1)) {
-        unset($U[$k]);
-        return $this->strip_urls( implode(' ',$U));
-      }
+  function containsTLD($string) {
+    preg_match(
+      "/(AC($|\/)|\.AD($|\/)|\.AE($|\/)|\.AERO($|\/)|\.AF($|\/)|\.AG($|\/)|\.AI($|\/)|\.AL($|\/)|\.AM($|\/)|\.AN($|\/)|\.AO($|\/)|\.AQ($|\/)|\.AR($|\/)|\.ARPA($|\/)|\.AS($|\/)|\.ASIA($|\/)|\.AT($|\/)|\.AU($|\/)|\.AW($|\/)|\.AX($|\/)|\.AZ($|\/)|\.BA($|\/)|\.BB($|\/)|\.BD($|\/)|\.BE($|\/)|\.BF($|\/)|\.BG($|\/)|\.BH($|\/)|\.BI($|\/)|\.BIZ($|\/)|\.BJ($|\/)|\.BM($|\/)|\.BN($|\/)|\.BO($|\/)|\.BR($|\/)|\.BS($|\/)|\.BT($|\/)|\.BV($|\/)|\.BW($|\/)|\.BY($|\/)|\.BZ($|\/)|\.CA($|\/)|\.CAT($|\/)|\.CC($|\/)|\.CD($|\/)|\.CF($|\/)|\.CG($|\/)|\.CH($|\/)|\.CI($|\/)|\.CK($|\/)|\.CL($|\/)|\.CM($|\/)|\.CN($|\/)|\.CO($|\/)|\.COM($|\/)|\.COOP($|\/)|\.CR($|\/)|\.CU($|\/)|\.CV($|\/)|\.CX($|\/)|\.CY($|\/)|\.CZ($|\/)|\.DE($|\/)|\.DJ($|\/)|\.DK($|\/)|\.DM($|\/)|\.DO($|\/)|\.DZ($|\/)|\.EC($|\/)|\.EDU($|\/)|\.EE($|\/)|\.EG($|\/)|\.ER($|\/)|\.ES($|\/)|\.ET($|\/)|\.EU($|\/)|\.FI($|\/)|\.FJ($|\/)|\.FK($|\/)|\.FM($|\/)|\.FO($|\/)|\.FR($|\/)|\.GA($|\/)|\.GB($|\/)|\.GD($|\/)|\.GE($|\/)|\.GF($|\/)|\.GG($|\/)|\.GH($|\/)|\.GI($|\/)|\.GL($|\/)|\.GM($|\/)|\.GN($|\/)|\.GOV($|\/)|\.GP($|\/)|\.GQ($|\/)|\.GR($|\/)|\.GS($|\/)|\.GT($|\/)|\.GU($|\/)|\.GW($|\/)|\.GY($|\/)|\.HK($|\/)|\.HM($|\/)|\.HN($|\/)|\.HR($|\/)|\.HT($|\/)|\.HU($|\/)|\.ID($|\/)|\.IE($|\/)|\.IL($|\/)|\.IM($|\/)|\.IN($|\/)|\.INFO($|\/)|\.INT($|\/)|\.IO($|\/)|\.IQ($|\/)|\.IR($|\/)|\.IS($|\/)|\.IT($|\/)|\.JE($|\/)|\.JM($|\/)|\.JO($|\/)|\.JOBS($|\/)|\.JP($|\/)|\.KE($|\/)|\.KG($|\/)|\.KH($|\/)|\.KI($|\/)|\.KM($|\/)|\.KN($|\/)|\.KP($|\/)|\.KR($|\/)|\.KW($|\/)|\.KY($|\/)|\.KZ($|\/)|\.LA($|\/)|\.LB($|\/)|\.LC($|\/)|\.LI($|\/)|\.LK($|\/)|\.LR($|\/)|\.LS($|\/)|\.LT($|\/)|\.LU($|\/)|\.LV($|\/)|\.LY($|\/)|\.MA($|\/)|\.MC($|\/)|\.MD($|\/)|\.ME($|\/)|\.MG($|\/)|\.MH($|\/)|\.MIL($|\/)|\.MK($|\/)|\.ML($|\/)|\.MM($|\/)|\.MN($|\/)|\.MO($|\/)|\.MOBI($|\/)|\.MP($|\/)|\.MQ($|\/)|\.MR($|\/)|\.MS($|\/)|\.MT($|\/)|\.MU($|\/)|\.MUSEUM($|\/)|\.MV($|\/)|\.MW($|\/)|\.MX($|\/)|\.MY($|\/)|\.MZ($|\/)|\.NA($|\/)|\.NAME($|\/)|\.NC($|\/)|\.NE($|\/)|\.NET($|\/)|\.NF($|\/)|\.NG($|\/)|\.NI($|\/)|\.NL($|\/)|\.NO($|\/)|\.NP($|\/)|\.NR($|\/)|\.NU($|\/)|\.NZ($|\/)|\.OM($|\/)|\.ORG($|\/)|\.PA($|\/)|\.PE($|\/)|\.PF($|\/)|\.PG($|\/)|\.PH($|\/)|\.PK($|\/)|\.PL($|\/)|\.PM($|\/)|\.PN($|\/)|\.PR($|\/)|\.PRO($|\/)|\.PS($|\/)|\.PT($|\/)|\.PW($|\/)|\.PY($|\/)|\.QA($|\/)|\.RE($|\/)|\.RO($|\/)|\.RS($|\/)|\.RU($|\/)|\.RW($|\/)|\.SA($|\/)|\.SB($|\/)|\.SC($|\/)|\.SD($|\/)|\.SE($|\/)|\.SG($|\/)|\.SH($|\/)|\.SI($|\/)|\.SJ($|\/)|\.SK($|\/)|\.SL($|\/)|\.SM($|\/)|\.SN($|\/)|\.SO($|\/)|\.SR($|\/)|\.ST($|\/)|\.SU($|\/)|\.SV($|\/)|\.SY($|\/)|\.SZ($|\/)|\.TC($|\/)|\.TD($|\/)|\.TEL($|\/)|\.TF($|\/)|\.TG($|\/)|\.TH($|\/)|\.TJ($|\/)|\.TK($|\/)|\.TL($|\/)|\.TM($|\/)|\.TN($|\/)|\.TO($|\/)|\.TP($|\/)|\.TR($|\/)|\.TRAVEL($|\/)|\.TT($|\/)|\.TV($|\/)|\.TW($|\/)|\.TZ($|\/)|\.UA($|\/)|\.UG($|\/)|\.UK($|\/)|\.US($|\/)|\.UY($|\/)|\.UZ($|\/)|\.VA($|\/)|\.VC($|\/)|\.VE($|\/)|\.VG($|\/)|\.VI($|\/)|\.VN($|\/)|\.VU($|\/)|\.WF($|\/)|\.WS($|\/)|\.XN--0ZWM56D($|\/)|\.XN--11B5BS3A9AJ6G($|\/)|\.XN--80AKHBYKNJ4F($|\/)|\.XN--9T4B11YI5A($|\/)|\.XN--DEBA0AD($|\/)|\.XN--G6W251D($|\/)|\.XN--HGBK6AJ7F53BBA($|\/)|\.XN--HLCJ6AYA9ESC7A($|\/)|\.XN--JXALPDLP($|\/)|\.XN--KGBECHTV($|\/)|\.XN--ZCKZAH($|\/)|\.YE($|\/)|\.YT($|\/)|\.YU($|\/)|\.ZA($|\/)|\.ZM($|\/)|\.ZW)/i",
+      $string,
+      $M);
+    $has_tld = (count($M) > 0) ? true : false;
+    return $has_tld;
+  }
+
+function cleaner($url) {
+  $U = explode(' ',$url);
+
+  $W =array();
+  foreach ($U as $k => $u) {
+    if (stristr($u,".")) { //only preg_match if there is a dot    
+      if ($this->containsTLD($u) === true) {
+      unset($U[$k]);
+      return $this->cleaner( implode(' ',$U));
+    }      
     }
-    return implode(' ',$U);
+  }
+  return implode(' ',$U);
+}
+
+  function removeEmoji($text) {
+
+    $clean_text = "";
+
+    // Match Emoticons
+    $regexEmoticons = '/[\x{1F600}-\x{1F64F}]/u';
+    $clean_text = preg_replace($regexEmoticons, '', $text);
+
+    // Match Miscellaneous Symbols and Pictographs
+    $regexSymbols = '/[\x{1F300}-\x{1F5FF}]/u';
+    $clean_text = preg_replace($regexSymbols, '', $clean_text);
+
+    // Match Transport And Map Symbols
+    $regexTransport = '/[\x{1F680}-\x{1F6FF}]/u';
+    $clean_text = preg_replace($regexTransport, '', $clean_text);
+
+    return $clean_text;
   }
   
   function get_cron_intervals(){
@@ -65,10 +96,10 @@ class PLATFORM_TWITTER Extends PLATFORM_BASE {
     
     if( is_array($response_object->entities->media) ){
       $this->pic_thumb            = $response_object->entities->media[0]->media_url . ":thumb";
-      $this->pic_full             = $response_object->entities->media[0]->media_url;       
+      $this->pic_full             = $response_object->entities->media[0]->media_url;
     }
     else{
-      $no_pic = $response_object->text;
+      $no_pic = $this->removeEmoji($response_object->text);
     }
     
     if( $plugin_options['only_with_pics'] == 'Yes' && $no_pic ){
@@ -78,32 +109,45 @@ class PLATFORM_TWITTER Extends PLATFORM_BASE {
     // remove hash tags from title and create tags with them
     $pattern = "/\#([a-z1-9^\S])+/";
     preg_match_all($pattern, $response_object->text, $hashtags_in_title);
-    $clean_title = $this->strip_urls(preg_replace($pattern, "", $response_object->text));
+
+    if($plugin_options['exclude_hashtags'] == 'Yes'){
+        $clean_title = $this->cleaner(preg_replace($pattern, "", $response_object->text));
+    } else {
+        $clean_title = $this->cleaner($response_object->text);
+    }
+    if($plugin_options['remove_emoji'] == 'Yes'){
+        $clean_title = $this->removeEmoji($clean_title);
+    }
+    
     
     $this->pic_strs             = str_replace("#", "", $hashtags_in_title[0]);
     $this->pic_mysqldate        = date( 'Y-m-d H:i:s', strtotime($response_object->created_at) );
-    $this->pic_handle           = $response_object->from_user;
-    $this->pic_username         = $response_object->from_user_name;
-    $this->pic_sha              = $response_object->id_str;
-    $this->pic_handle_avatar    = $response_object->profile_image_url;
+    $this->pic_handle           = $response_object->user->screen_name;
+    $this->pic_username         = $response_object->user->name;
+    $this->pic_sha              = $response_object->id;
+    $this->pic_handle_avatar    = $response_object->user->profile_image_url;
     $this->pic_handle_platform  = 'twitter';
     $this->pic_platform         = 'twitter';
+    $this->pic_link             = 'https://twitter.com/' . $response_object->user->screen_name . '/status/' . $response_object->id_str;
+
     if( $response_object->geo != '' ){
       $this->pic_loc              = implode(",", $response_object->geo);
     }
-    if($response_object->hashtags[0]){
+    if($response_object->entities->hashtags[0]){
       $this->pic_tags = array();
       foreach($response_object->entities->hashtags as $tag){
         array_push($this->pic_tags, $tag->text);
       }      
     }
-    $this->pic_full_title         = $response_object->text;
-    $this->pic_clean_title        = $no_pic ? $no_pic : (trim($clean_title) ? $clean_title : $this->pic_handle . ' using ' . $this->pic_handle_platform);
-    
+
+    $this->pic_full_title         = $this->removeEmoji($response_object->text);
+    $this->pic_clean_title        = $no_pic ? $no_pic : ($clean_title ? $clean_title : $this->pic_handle . ' using ' . $this->pic_handle_platform);
+
+
     return true;
   }
   function clean_response($response_object){
-    return $response_object->results;
+    return $response_object->statuses;
   }
   function get_next_page($response_object, $last_page){
     if(stristr($last_page, "page=")){
@@ -173,6 +217,33 @@ class PLATFORM_TWITTER Extends PLATFORM_BASE {
             		<code>Skip text-only tweets</code>
             	</th>
             </tr>
+
+            <tr class="active">
+              <td class="desc">
+                <select name="social_hashtag_cache[<?php print $cache_num ?>][exclude_hashtags]" class="disable_onchange" >
+                  <option value="No" <?php selected( $cache_settings['exclude_hashtags'], 'No' ); ?>>No</option>
+                  <option value="Yes" <?php selected( $cache_settings['exclude_hashtags'], 'Yes' ); ?>>Yes</option>
+                </select> 
+              </td>
+              <th scope="row">
+                <label for="">Exclude Hashtags</label><br/>
+                <code>Will remove hashtagged words from retrieved posts.</code>
+              </th>
+            </tr>
+
+            <tr class="active">
+              <td class="desc">
+                <select name="social_hashtag_cache[<?php print $cache_num ?>][remove_emoji]" class="disable_onchange" >
+                  <option value="No" <?php selected( $cache_settings['remove_emoji'], 'No' ); ?>>No</option>
+                  <option value="Yes" <?php selected( $cache_settings['remove_emoji'], 'Yes' ); ?>>Yes</option>
+                </select> 
+              </td>
+              <th scope="row">
+                <label for="">Remove Emoji</label><br/>
+                <code>Will remove emoji unicode-range characters from retrieved posts.</code>
+              </th>
+            </tr>
+
             <tr class="active">
               <td class="desc">
             	  <select name="social_hashtag_cache[<?php print $cache_num ?>][skip_retweets]" class="disable_onchange" >
@@ -374,10 +445,19 @@ class PLATFORM_TELEPORTD Extends PLATFORM_BASE {
 class PLATFORM_INSTAGRAM Extends PLATFORM_BASE {
   function parse_response($response_object, $plugin_options){
     $this->unset_variables();
+
     // remove hash tags from title and create tags with them
     $pattern = "/\#([a-z1-9^\S])+/";
     preg_match_all($pattern, $response_object->caption->text, $hashtags_in_title);
-    $clean_title = preg_replace($pattern, "", $response_object->caption->text);
+
+    if($plugin_options['exclude_hashtags'] == 'Yes'){
+        $clean_title = $this->cleaner(preg_replace($pattern, "", $response_object->caption->text));
+    } else {
+        $clean_title = $this->cleaner($response_object->caption->text);
+    }
+    if($plugin_options['remove_emoji'] == 'Yes'){
+        $clean_title = $this->removeEmoji($clean_title);
+    }
     
     $this->pic_tags             = $response_object->tags;
     $this->pic_loc              = !empty($response_object->location->latitude)?$response_object->location->latitude . "," . $response_object->location->longitude:'';
@@ -391,8 +471,9 @@ class PLATFORM_INSTAGRAM Extends PLATFORM_BASE {
     $this->pic_handle_platform  = 'instagram';    
     $this->pic_username         = $response_object->user->full_name;
     $this->pic_platform         = 'instagram';
-    $this->pic_full_title       = urlencode($response_object->caption->text);
+    $this->pic_full_title       = urlencode($this->removeEmoji($response_object->caption->text));
     $this->pic_clean_title      = trim($clean_title) != '' ? $clean_title : $this->pic_handle . ' using ' . $this->pic_handle_platform;
+    $this->pic_link             = $response_object->link;
     return true;
   }
   function clean_response($response_object){
@@ -428,6 +509,33 @@ class PLATFORM_INSTAGRAM Extends PLATFORM_BASE {
                 <code>Instagram requires that you <a target="_blank" href="http://instagram.com/developer/clients/manage/">register a 'client' application</a><br/>(it's free & takes about 5 minutes to set up)</code>
             	</th>
             </tr>
+
+            <tr class="active">
+              <td class="desc">
+                <select name="social_hashtag_cache[<?php print $cache_num ?>][exclude_hashtags]" class="disable_onchange" >
+                  <option value="No" <?php selected( $cache_settings['exclude_hashtags'], 'No' ); ?>>No</option>
+                  <option value="Yes" <?php selected( $cache_settings['exclude_hashtags'], 'Yes' ); ?>>Yes</option>
+                </select> 
+              </td>
+              <th scope="row">
+                <label for="">Exclude Hashtags</label><br/>
+                <code>Will remove hashtagged words from retrieved posts.</code>
+              </th>
+            </tr>
+
+            <tr class="active">
+              <td class="desc">
+                <select name="social_hashtag_cache[<?php print $cache_num ?>][remove_emoji]" class="disable_onchange" >
+                  <option value="No" <?php selected( $cache_settings['remove_emoji'], 'No' ); ?>>No</option>
+                  <option value="Yes" <?php selected( $cache_settings['remove_emoji'], 'Yes' ); ?>>Yes</option>
+                </select> 
+              </td>
+              <th scope="row">
+                <label for="">Remove Emoji</label><br/>
+                <code>Will remove emoji unicode-range characters from retrieved posts.</code>
+              </th>
+            </tr>
+
             <tr class="active">
               <td class="desc">
                 <p><input type="text" name="social_hashtag_cache[<?php print $cache_num ?>][search_name]" value="<?php print ($cache_settings['search_name'] ? $cache_settings['search_name'] : $cache_settings['api_selected']) ?>" class="regular-text disable_onchange" /></p>

--- a/lib/posttypes.php
+++ b/lib/posttypes.php
@@ -26,7 +26,7 @@ function create_social_hashtag_posttype() {
       'not_found_in_trash' => __( 'No social hashtag found in trash' )
     ),
     'public' => true,
-    'supports' => array( 'title', 'thumbnail', 'editor', 'custom-fields'),
+    'supports' => array( 'title', 'author', 'thumbnail', 'editor', 'custom-fields'),
     'capability_type' => 'post',
     'has_archive' => $slug,
     'hierarchical' => false,

--- a/lib/shortcodes.php
+++ b/lib/shortcodes.php
@@ -2,6 +2,8 @@
 
 // this is under construction :)
 
+// After a fair amount of sleuthing, I am convinced that this file does not do anything -- Michael Mandiberg, June, 2014
+
 add_shortcode('social_hashtag_pics', 'display_social_hashtag_pics');
 function display_social_hashtag_pics( $atts ) {
 	global $post;

--- a/lib/social_hashtag.class.php
+++ b/lib/social_hashtag.class.php
@@ -1,11 +1,14 @@
 <?php
 /*
  * @author      Bryan Shanaver <bryan[at]fiftyandfifty[dot]org>
+ * @edited by Jonathan Kiritharan <jkiritharan[at]gmail[dot]com> in June 2014
  */
 
+//I was having some problems figuring out how to return an error or any data back while testing on wp-admin->settings->social-hashtags alert box
+//sending an email worked best in returning code and variables I wanted to see : mail("yourName@mailinator.com", "subject", (string)print_r($variable,true));
 if( !class_exists('SOCIAL_HASHTAG_CACHE') ) {
 class SOCIAL_HASHTAG_CACHE {
-
+  
   var $api_options = array(
 
     'instagram' => array(
@@ -24,14 +27,14 @@ class SOCIAL_HASHTAG_CACHE {
     ),
     //
     // need to rebuild this for the new OAuth v1.1 API calls...
-    // 'twitter' => array(
-    //   'api_scheme' => 'http',
-    //   'api_host' => 'api.twitter.com',
-    //   'api_port' => '',
-    //   'api_endpoint' => '1.1/search/tweets.json?q=%string%',
-    //   'auth_type' => ''
-    // ),
-    //
+    'twitter' => array(
+      'api_scheme' => 'https',
+      'api_host' => 'api.twitter.com',
+      'api_port' => '',
+      'api_endpoint' => '1.1/search/tweets.json?include_entities=true&q=%string%',
+      'auth_type' => ''
+    ),
+    // 
     // this may still work, but it's a little redundant, so hiding...
     // 'teleportd' => array(
     //   'api_scheme' => 'http',
@@ -51,16 +54,14 @@ class SOCIAL_HASHTAG_CACHE {
     'location' => '',
     'cron_interval' => 'manual'
   );
-
+  
   var $teleportd, $instagram, $twitter, $youtube;
 
-  var $debug              = false;
-
-  var $cpt_slug           = 'social';
+  var $debug = false;
 
   var $global_options     = 'social_hashtag-global';
   var $social_api_options = 'social_hashtag-apis';
-
+  
   function __construct() {
     $this->teleportd = new PLATFORM_TELEPORTD();
     $this->instagram = new PLATFORM_INSTAGRAM();
@@ -68,7 +69,7 @@ class SOCIAL_HASHTAG_CACHE {
     $this->youtube = new PLATFORM_YOUTUBE();
     $this->add_archive_template();
   }
-
+  
   function choose_platform($name){
     switch( $name ) {
       case "instagram":
@@ -86,9 +87,9 @@ class SOCIAL_HASHTAG_CACHE {
       default:
         //wp_die( __('Missing Platform class') );
     }
-    return $platform;
+    return $platform;    
   }
-
+  
   function add_archive_template(){
     add_filter('archive_template', array(&$this, 'social_hashtag_custom_archive_template'), 10, 2);
   }
@@ -100,17 +101,17 @@ class SOCIAL_HASHTAG_CACHE {
     }
     return $template;
   }
-
+  
   function get_available_postypes(){
     $args=array(
       'public'   => true
-    );
+    ); 
     $output = 'names'; // names or objects, note names is the default
     $operator = 'or'; // 'and' or 'or'
     $post_types = get_post_types( $args, $output, $operator );
     return $post_types;
   }
-
+ 
   function save_option($id, $value) {
     $option_exists = (get_option($id, null) !== null);
     if ($option_exists) {
@@ -118,78 +119,81 @@ class SOCIAL_HASHTAG_CACHE {
     } else {
       add_option($id, $value);
     }
-  }
-
+  }  
+  
   function import_item($photos, $platform, $platform_options, $plugin_options){
     global $wpdb;
-
+    
     require_once(ABSPATH . "wp-admin" . '/includes/image.php');
     $wordpress_uploads = wp_upload_dir();
-
-    $blacklist = explode(',', $plugin_options['blacklisted_users']);
-
+    
+    $blacklist = array_filter(explode(',', $plugin_options['blacklisted_users']));
+    $whitelist = array_filter(explode(',', $plugin_options['whitelisted_users']));
+    
+    
     $retrieved = 0;
     $added = 0;
-
+    $blocked = 0;
+    
     try {
-
+  
         foreach( $photos as $num => $photo ) {
 
           if( $plugin_options['max_items'] && $retrieved >= $plugin_options['max_items'] ){ break; }
-
-          if( !$platform->parse_response($photo, $platform_options) ){
+          
+          if( !$platform->parse_response($photo, $platform_options) ){ 
             if($plugin_options['debug_on']){
               social_hashtag_logging($platform->pic_full_title . "\n[not added] parsing error ", 1);
-              continue;
+              continue; 
             }
           }
-
           $retrieved++;
+          // Check to see if this user is whitelisted, skip to the next one if not   
+          if( !empty($whitelist) ){    
+            if(  array_search ( $platform->pic_handle, $whitelist ) === false ){
+              continue;
+            } 
+          }
 
-          // Check to see if this user is blacklisted, skip to the next on if so
-          if( count($blacklist) ){
-            if(  array_search ( $platform->pic_handle, $blacklist ) ){
-              if($plugin_options['debug_on']){
-                social_hashtag_logging($platform->pic_full_title . "\n[not added] blacklisted user: " . $platform->pic_handle, 1); }
-                continue;
+          // Check to see if this user is blacklisted, skip to the next one if so   
+          if( !empty($blacklist) ){  
+            if(  array_search ( $platform->pic_handle, $blacklist ) ){  
+                continue; 
               }
           }
 
-          // Check to see if this is a retweet, skip to the next on if so
+          // Check to see if this is a retweet, skip to the next on if so  
           if( @$platform_options['skip_retweets'] == 'Yes' ){
             if(  strstr ( $platform->pic_full_title , 'RT ') ){ if($plugin_options['debug_on']){
               social_hashtag_logging($platform->pic_full_title . "\n[not added] Retweet suspected : ".$platform->pic_full_title, 1); }
-              continue;
+              continue; 
             }
           }
-
           // Check to see if we already have this photo, skip to the next one if we do
-          $existing_photo = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->postmeta WHERE meta_key = 'social_hashtag_sha' and meta_value = %s", $platform->pic_sha ) );
+          $existing_photo = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->postmeta WHERE meta_key = 'social_hashtag_sha' and meta_value = %s", $platform->pic_sha ) );          
           if( count($existing_photo) >= 1 ){ if($plugin_options['debug_on']){
             social_hashtag_logging($platform->pic_full_title . "\n[not added] we already have this one ", 1); }
-            continue;
+            continue; 
           }
           else{ if($plugin_options['debug_on']){social_hashtag_logging($platform->pic_full_title, 1);} }
 
           $added++;
-
           // if there is a thumnail, process the thumbnail, and attach it
           if( $platform->pic_thumb != '' ) {
             $thumb_imagesize = getimagesize($platform->pic_thumb);
             $img_name = strtolower( preg_replace('/[\s\W]+/','-', $platform->pic_clean_title) );
             $image_file = file_get_contents( $platform->pic_thumb );
             $img_filetype = wp_check_filetype( $platform->pic_thumb, null );
-            if( !$img_filetype['ext'] ){
+            if( !$img_filetype['ext'] ){ 
               $img_filetype['ext'] = 'jpg';
               $img_filetype['type'] = 'image/jpeg';
-            }
+            }           
             $img_path = $wordpress_uploads['path'] . "/" . $img_name . "." . $img_filetype['ext'];
             $img_sub_path = $wordpress_uploads['subdir'] . "/" . $img_name . "." . $img_filetype['ext'];
             file_put_contents($img_path , $image_file);
           }else{
             unset($full_imagesize);
           }
-
           // if there is a large image, process it
           if( $platform->pic_full != '' ) {
             $full_imagesize = getimagesize($platform->pic_full);
@@ -197,15 +201,14 @@ class SOCIAL_HASHTAG_CACHE {
               $post_content = $platform->pic_post_content;
             }
             else{
-              $post_content = "<img src='".$platform->pic_full ."' alt='".$platform->pic_clean_title ."' />";
+              $post_content = "<img src='".$platform->pic_full ."' alt='".$platform->pic_clean_title ."' />"; 
             }
           }else{
             unset($thumb_imagesize);
             $post_content = $platform->pic_full_title;
           }
-
           $post = array(
-           'post_author' => 1,
+           'post_author' => !empty($plugin_options['author_id'])?$plugin_options['author_id']:1,
            'post_date' => $platform->pic_mysqldate ,
            'post_type' => 'social_hashtag',
            'post_title' => $platform->pic_clean_title,
@@ -213,11 +216,14 @@ class SOCIAL_HASHTAG_CACHE {
            'post_status' => ($plugin_options['always_private'] == 'No' ? 'publish' : 'private' ),
           );
           $post_id = wp_insert_post( $post, true );
-
           add_post_meta($post_id, 'social_hashtag_sha', $platform->pic_sha, true);
           add_post_meta($post_id, 'social_hashtag_platform', $platform->pic_handle_platform, true);
           add_post_meta($post_id, 'social_hashtag_userhandle', $platform->pic_handle, true);
           add_post_meta($post_id, 'social_hashtag_location', $platform->pic_loc, true);
+          //figure out how to dynamically add url for user_link
+          add_post_meta($post_id, 'social_hashtag_user_link', "https://" . $platform->pic_platform . ".com/" . $platform->pic_handle, true);
+          add_post_meta($post_id, 'social_hashtag_post_link', $platform->pic_link, true);
+          add_post_meta($post_id, 'social_hashtag_timestamp', $platform->pic_mysqldate);
           if( $platform->vid_embed ) {
             add_post_meta($post_id, 'social_hashtag_vid_embed', $platform->vid_embed, true);
           }
@@ -237,15 +243,12 @@ class SOCIAL_HASHTAG_CACHE {
             );
             $attachment_id = wp_insert_post( $attachment, true );
             add_post_meta($attachment_id, '_wp_attached_file', $img_sub_path, true );
-            add_post_meta($attachment_id, '_wp_attachment_metadata', array('height' => 150, 'width' => 150,), true );
-            add_post_meta($attachment_id, 'social_hashtag_thumb_url', $platform->pic_thumb, true );
             add_post_meta($post_id, 'social_hashtag_thumb_url', $platform->pic_thumb, true);
             add_post_meta($post_id, 'social_hashtag_thumb_imagesize', ('w'.$thumb_imagesize[0].'xh'.$thumb_imagesize[1]), true);
           }
-
           $category_ids = array();
           $tag_ids = array();
-
+          
           // link post to the platform 'category'
           $new_category = term_exists( $platform->pic_handle_platform, 'social_hashtag_categories');
           if( $new_category ){
@@ -256,7 +259,7 @@ class SOCIAL_HASHTAG_CACHE {
               array_push( $category_ids, (int)$new_term['term_id'] );
             }
           }
-
+          
           // link post to the api_search_name category
           if( $this->plugin_options['search_name'] ){
             $new_category = term_exists( $this->plugin_options[search_name], 'social_hashtag_categories');
@@ -269,120 +272,125 @@ class SOCIAL_HASHTAG_CACHE {
               }
             }
           }
-
           // attach these categories to the new post
           if( count($category_ids) ) {
             wp_set_post_terms( $post_id, $category_ids, 'social_hashtag_categories' );
           }
-
           // attach these tags to the new post
           if( count($platform->pic_tags) ) {
             wp_set_object_terms($post_id, $platform->pic_tags, 'social_hashtag_tags');
           }
-
+          
           // attach these tags to the new post
           if( count($platform->pic_strs) ) {
             wp_set_object_terms($post_id, $platform->pic_strs, 'social_hashtag_tags');
           }
-
-
         }
 
-        return $platform->pic_handle_platform . " complete! " . $retrieved . " records retrieved, " . $added . " records added ";
+        return $platform->pic_handle_platform . " complete! ". $blocked . " blocked, " . $retrieved . " records retrieved, " . $added . " records added ";
 
     } catch (Exception $e) {
-        return 'Error: ' . $e->getMessage();
     }
-
+    
   }
-
+  
   function run_social_hashtag_query($num=0){
-
+    
     $global_options = $this->get_social_hashtag_options(null, 'global');
 
     $all_api_options = $this->get_social_hashtag_options();
     $platform_options = $all_api_options[$num];
     $platform = $this->choose_platform($platform_options['api_selected']);
-
+    
     $search_url = $this->build_api_search_url($num);
-
+    
     $count_items = 0;
 
     $results = "";
-
+    
     while( strlen($search_url) > 10 ){
-
+      
       if( !empty($global_options['debug_on']) ){social_hashtag_logging('API url: ' . $search_url, 1);}
 
-      $json_string = $this->remote_get_contents($search_url);
-      $response = json_decode($json_string);
-      $photos = $platform->clean_response($response);
-
+      if($platform_options['api_selected'] == "twitter"){
+        $json_string=$this->oauth($search_url);
+        $json_string = utf8_encode($json_string);
+        $json_string=html_entity_decode($json_string);
+        $response = json_decode($json_string);
+        $photos = $platform->clean_response($response);
+      }
+      else{
+       $json_string = $this->remote_get_contents($search_url);
+       
+       $response = json_decode($json_string);
+       $photos = $platform->clean_response($response);
+      }
+      
       if( !is_array($photos) ){
         return "No results found";
         break;
       }
-
+      
       if( !empty($global_options['debug_on']) ){social_hashtag_logging('total items returned from API: ' . count($photos), 1);}
 
       $results .= $this->import_item($photos, $platform, $platform_options, $global_options);
-
+      
       $count_items = count($photos) + $count_items;
       if($count_items > $global_options['max_items'] && $global_options['max_items']){
         if( !empty($global_options['debug_on']) ){social_hashtag_logging('Max results settings hit: ' . $global_options['max_items'], 1);}
         break;
       }
-
+      
       $platform->get_next_page($response, $search_url);
       $search_url = $platform->next_page;
-
+      
     }
 
     return $results;
 
   }
-
+  
   function build_api_search_url($option_num=0){
-
+    
     $plugin_options = $this->get_social_hashtag_options();
     $api_settings = $this->get_social_hashtag_options($option_num);
     $api_options = $this->api_options[$api_settings['api_selected']];
-
+  
     $query = $api_options['api_scheme'] . "://" . $api_options['api_host'];                                           //| http://v1.api.social_hashtag.com
     if( $api_options['api_port'] != '' ){ $query .= ":" . $api_options['api_port']; }                                 //| http://v1.api.social_hashtag.com:8080
     $query .= "/" . str_replace("%string%", urlencode($api_settings['string']), $api_options['api_endpoint'] );     //| http://v1.api.social_hashtag.com:8080/search?string=xxxx
-
+    
     if( $api_options['auth_type'] ){
       $query .= "&" . $api_options['auth_type'] . "=" . $api_settings['api_authentication'];                         //| http://v1.api.social_hashtag.com:8080/search?string=xxxx&apikey=xxxxxxxxxx
     }
-
+  
     if( $api_settings['api_selected'] == 'social_hashtag' ) {
       $query.= "&window=50";
-      $query.= "&period=" . $api_settings['period'];
-      $query.= "&location=" . urlencode($api_settings['location']);
+      $query.= "&period=" . $api_settings['period'];    
+      $query.= "&location=" . urlencode($api_settings['location']); 
     }
 
     if( $api_settings['api_selected'] == 'instagram' ) {
-      //$query.= "&max_tag_id=1334773328821";
+      //$query.= "&max_tag_id=1334773328821"; 
     }
-
+    
     if( $api_settings['api_selected'] == 'twitter' ) {
       $query.= "&rpp=100";
       $query.= "&result_type=mixed&include_entities=true";
-      $query.= "&until=" . urlencode($api_settings['period']);
-      $query.= "&geocode=" . urlencode($api_settings['location']);
+      $query.= "&until=" . urlencode($api_settings['period']); 
+      $query.= "&geocode=" . urlencode($api_settings['location']); 
     }
-
+    
     if( $api_settings['api_selected'] == 'youtube' ) {
       $query.= "&max-results=50";
       $query.= "&v=2&alt=jsonc";
     }
-
+    
     return $query;
   }
 
   function get_social_hashtag_options($option_num=null, $type='api'){
-    $options = get_option( ($type=='api'?$this->social_api_options:$this->global_options) );
+    $options = get_option( ($type=='api'?$this->social_api_options:$this->global_options) );    
     if ( !empty($options[$option_num]) ) {
       return $options[$option_num];
     }
@@ -392,24 +400,24 @@ class SOCIAL_HASHTAG_CACHE {
     else {
       return $options;
     }
-  }
-
+  }  
+  
   function add_cron_intervals( $schedules ) {
-  	$schedules['five_minutes'] = array(
-  		'interval' => 300,
-  		'display' => __('[social_hashtag-cache] Five Minutes')
-  	);
-  	$schedules['ten_minutes'] = array(
-  		'interval' => 600,
-  		'display' => __('[social_hashtag-cache] Ten Minutes')
-  	);
-  	$schedules['thirty_minutes'] = array(
-  		'interval' => 1800,
-  		'display' => __('[social_hashtag-cache] Thirty Minutes')
-  	);
-  	return $schedules;
+    $schedules['five_minutes'] = array(
+      'interval' => 300,
+      'display' => __('[social_hashtag-cache] Five Minutes')
+    );
+    $schedules['ten_minutes'] = array(
+      'interval' => 600,
+      'display' => __('[social_hashtag-cache] Ten Minutes')
+    );
+    $schedules['thirty_minutes'] = array(
+      'interval' => 1800,
+      'display' => __('[social_hashtag-cache] Thirty Minutes')
+    );
+    return $schedules;
   }
-
+  
   // this function either runs from cron or manually from admin - if it runs without a num, it does all the searches
   function get_social_hashtag_pics($num=null) {
     if( is_numeric($num) ) {
@@ -422,7 +430,7 @@ class SOCIAL_HASHTAG_CACHE {
       }
     }
   }
-
+  
   function remote_get_contents($url) {
     if (function_exists('curl_get_contents') AND function_exists('curl_init')){
       if($this->debug){print "\n- USING CURL \n";}
@@ -432,6 +440,58 @@ class SOCIAL_HASHTAG_CACHE {
       if($this->debug){print "\n- USING file_get_contents \n";}
       return file_get_contents($url);
     }
+  }
+  function oauth($url){
+    //These are our constants.
+    include_once("oauth.php");
+ 
+
+$api_base = 'https://api.twitter.com/';
+$bearer_token_creds = base64_encode($app_key.':'.$app_token);
+ 
+//Get a bearer token.
+$opts = array(
+'http'=>array(
+'method' => 'POST',
+'header' => 'Authorization: Basic '.$bearer_token_creds."\r\n".
+'Content-Type: application/x-www-form-urlencoded;charset=UTF-8',
+'content' => 'grant_type=client_credentials'
+)
+);
+ 
+$context = stream_context_create($opts);
+$json = file_get_contents($api_base.'oauth2/token',false,$context);
+ 
+$result = json_decode($json,true);
+ 
+if (!is_array($result) || !isset($result['token_type']) || !isset($result['access_token'])) {
+die("Something went wrong. This isn't a valid array: ".$json);
+}
+ 
+if ($result['token_type'] !== "bearer") {
+die("Invalid token type. Twitter says we need to make sure this is a bearer.");
+}
+ 
+ 
+//Set our bearer token. Now issued, this won't ever* change unless it's invalidated by a call to /oauth2/invalidate_token.
+//*probably - it's not documentated that it'll ever change.
+$bearer_token = $result['access_token'];
+ 
+//Try a twitter API request now.
+$opts = array(
+'http'=>array(
+'method' => 'GET',
+'header' => 'Authorization: Bearer '.$bearer_token
+)
+);
+ 
+$context = stream_context_create($opts);
+// $json = file_get_contents($api_base.'1.1/search/tweets.json?q=artspracticum%20or%20%23artspracticum&since_id=0',false,$context);
+
+    
+      if($this->debug){print "\n- USING file_get_contents \n";}
+      return file_get_contents($url,false,$context);
+    
   }
 
   function curl_get_contents($url) {
@@ -443,7 +503,7 @@ class SOCIAL_HASHTAG_CACHE {
     curl_close($ch);
     return $output;
   }
-
-
+  
+    
   }
 }

--- a/lib/social_hashtag.css
+++ b/lib/social_hashtag.css
@@ -1,21 +1,24 @@
-#social_hashtags ul {
-	list-style: none 
+
+.the-social-posts {
+
 }
-#social_hashtags ul li {
-	display: inline-block; 
+
+div.a-social-post {
+	float: left;
+	width: 330px;
+	Padding: 15px;
+
 }
-#social_hashtags ul li img, #social_hashtags ul li iframe#ytplayer, #social_hashtags ul li details {
-	width: 200px;
+
+
+div.a-social-post img {
+	width: 300px;
+
 }
-#social_hashtags ul li iframe#ytplayer {
-	height: 150px;
-}
-#social_hashtags ul li details {
-	height: 50px;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	font-size: .75em;
-}
-#social_hashtags ul li a {
-	text-decoration: none;
+
+
+.clear {
+
+	 clear:both;
+
 }

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
-=== Social Hashtags ===
-Contributors: shanaver
+====== Social Hashtags ======
+Contributors: shanaver, mandiberg
 Tags: instagram, youtube, hashtags, videos, photos, images, API, twitter, teleportd
 Requires at least: 3.0.1
 Tested up to: 3.8
@@ -8,6 +8,10 @@ License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 Grabs images & videos matching any hashtag from social APIs like instagram & youtube.
+
+== Update Plans ==
+
+We are going to upgrade twitter to oAuth, and clean up the layout.
 
 == Description ==
 

--- a/social_hashtag-options.php
+++ b/social_hashtag-options.php
@@ -45,9 +45,11 @@
   $global_options     = $social_hashtag_cache->get_social_hashtag_options(null, 'global');
   $slug               = !empty($global_options['slug'])?$global_options['slug']:$social_hashtag_cache->cpt_slug;
   $debug_on           = !empty($global_options['debug_on'])?$global_options['debug_on']:'0';
+  $author_id          = !empty($global_options['author_id'])?$global_options['author_id']:1;
   $always_private     = !empty($global_options['always_private'])?$global_options['always_private']:'No';
   $max_items          = !empty($global_options['max_items'])?$global_options['max_items']:'50';
   $blacklisted_users  = !empty($global_options['blacklisted_users'])?$global_options['blacklisted_users']:'';
+  $whitelisted_users  = !empty($global_options['whitelisted_users'])?$global_options['whitelisted_users']:'';
 
 ?>
 
@@ -202,6 +204,7 @@
       		<code>Debugging info will be sent to the log<br/>(requires installing the <a href="http://wordpress.org/plugins/wordpress-logging-service/">WLS plugin</a>)</code>
       	</th>
       </tr>
+
       <tr class="active">
         <td class="desc">
       	  <select name="social_hashtag_global[always_private]" class="disable_onchange" >
@@ -223,6 +226,25 @@
       		<code>Set to 0 for no max - this may take a long time to run since some services only let you grab 50 at a time.</code>
       	</th>
       </tr>
+
+      <tr class="active">
+        <td class="desc">
+          <select name="social_hashtag_global[author_id]" class="disable_onchange" >
+            <?php
+              $blogusers = get_users( 'orderby=ID' );
+              // Array of WP_User objects.
+              foreach ( $blogusers as $user ) {
+                echo '<option value="' . $user->ID . '"' . selected( $author_id, $user->ID) . '>' . $user->display_name . '</option>';
+              }
+            ?>
+          </select>
+        </td>
+        <th scope="row">
+          <label for="">Set Author</label><br/>
+          <code>Will set the WP user to use as author of social-hashtags posts.</code>
+        </th>
+      </tr>
+
       <tr class="active">
         <td class="desc">
           <p><textarea name="social_hashtag_global[blacklisted_users]" cols="80" rows="4"><?php print $blacklisted_users ?></textarea></p>
@@ -232,6 +254,17 @@
       		<code>comma separated</code>
       	</th>
       </tr>
+
+      <tr class="active">
+        <td class="desc">
+          <p><textarea name="social_hashtag_global[whitelisted_users]" cols="80" rows="4"><?php print $whitelisted_users ?></textarea></p>
+        </td>
+        <th scope="row">
+          <label for="">Whitelisted usernames/handles</label><br/>
+          <code>comma separated</code>
+        </th>
+      </tr>
+
     </tbody>
 	</table>
 


### PR DESCRIPTION
Hi Bryan, here are the changes made by Team Mandiberg.

You can see the code working here: http://www.artspracticum.org/social/

The full granular commit info is here: https://github.com/mandiberg/social-hashtags (I couldn't get the old fork to point to the new base... so doing it by brute force.)
- Added option to keep or remove hashtagged words in retrieved posts.
- Added functionality to store more metadata from posts retrieved from
  Twitter and Instagram, including:
  - URL to post on Twitter/Instagram
  - URL to user on Twitter/Instagram
  - Timestamp for post from Twitter/Instagram
- Exposed metadata from retrieved posts to be displayed in the archive
  page.
- Added option to keep or remove Emoji from retrieved posts.
- Added option to whitelist usernames.
- Added option to pick a wordpress user to use as the author for
  social-hashtag posts.
